### PR TITLE
Fix global dd and dump

### DIFF
--- a/src/scripts/global-ray-loader.php
+++ b/src/scripts/global-ray-loader.php
@@ -5,17 +5,18 @@ namespace Spatie\GlobalRay;
 include_once __DIR__ . "/../Support/Ray.php";
 include_once __DIR__ . "/../Support/Dump.php";
 
-use Spatie\GlobalRay\Support\Ray;
 use Spatie\GlobalRay\Support\Dump;
+use Spatie\GlobalRay\Support\Ray;
 
-class PharLoader {
+class PharLoader
+{
     public static function load(string $pharPath, array $unlessDetectedPackages)
     {
         $composerJson = getcwd() . '/composer.json';
 
         if (file_exists($composerJson)) {
             $composer = json_decode(file_get_contents($composerJson), true);
-    
+
             foreach (['require', 'require-dev'] as $require) {
                 foreach ($composer[$require] ?? [] as $package => $version) {
                     if (in_array($package, $unlessDetectedPackages)) {
@@ -24,7 +25,7 @@ class PharLoader {
                 }
             }
         }
-    
+
         if (file_exists($pharPath)) {
             include_once $pharPath;
         }

--- a/src/scripts/global-ray-loader.php
+++ b/src/scripts/global-ray-loader.php
@@ -1,12 +1,52 @@
 <?php
 
-use Spatie\GlobalRay\Support\Dump;
+namespace Spatie\GlobalRay;
+
+include_once __DIR__ . "/../Support/Ray.php";
+include_once __DIR__ . "/../Support/Dump.php";
+
 use Spatie\GlobalRay\Support\Ray;
+use Spatie\GlobalRay\Support\Dump;
+
+class PharLoader {
+    public static function load(string $pharPath, array $unlessDetectedPackages)
+    {
+        $composerJson = getcwd() . '/composer.json';
+
+        if (file_exists($composerJson)) {
+            $composer = json_decode(file_get_contents($composerJson), true);
+    
+            foreach (['require', 'require-dev'] as $require) {
+                foreach ($composer[$require] ?? [] as $package => $version) {
+                    if (in_array($package, $unlessDetectedPackages)) {
+                        return;
+                    }
+                }
+            }
+        }
+    
+        if (file_exists($pharPath)) {
+            include_once $pharPath;
+        }
+    }
+
+    public static function isRunningTinkerwell()
+    {
+        return defined('STDIN')
+            && strpos($_SERVER['argv'][0] ?? '', 'tinker.phar') !== false;
+    }
+}
 
 try {
-    include_once __DIR__ . "/../Support/Ray.php";
-    $rayPharPath = Ray::getPharPath();
-    globalRayPharLoader($rayPharPath, [
+    if (! PharLoader::isRunningTinkerwell()) {
+        PharLoader::load(Dump::getPharPath(), [
+            'laravel/framework',
+            'illuminate/support',
+            'symfony/var-dumper',
+        ]);
+    }
+
+    PharLoader::load(Ray::getPharPath(), [
         'spatie/ray',
         'spatie/yii-ray',
         'spatie/craft-ray',
@@ -14,33 +54,9 @@ try {
         'spatie/wordpress-ray',
     ]);
 
-    include_once __DIR__ . "/../Support/Dump.php";
-    $dumpPharPath = Dump::getPharPath();
-    globalRayPharLoader($dumpPharPath, [
-        'laravel/framework',
-        'illuminate/support',
-        'symfony/var-dumper',
-    ]);
-} catch (Throwable $exception) {
-}
-
-function globalRayPharLoader(string $pharPath, array $unlessDetectedPackages)
-{
-    $composerJson = getcwd() . '/composer.json';
-
-    if (file_exists($composerJson)) {
-        $composer = json_decode(file_get_contents($composerJson), true);
-
-        foreach (['require', 'require-dev'] as $require) {
-            foreach ($composer[$require] ?? [] as $package => $version) {
-                if (in_array($package, $unlessDetectedPackages)) {
-                    return;
-                }
-            }
-        }
-    }
-
-    if (file_exists($pharPath)) {
-        include_once $pharPath;
-    }
+    // This empties the global configuration used in Composer autoloader
+    // file `autoload_real.php`. Without it, conflicts may appear
+    // with projects using same dependencies as this package.
+    $GLOBALS['__composer_autoload_files'] = [];
+} catch (\Throwable $exception) {
 }

--- a/tests/Integration/GlobalRayLoaderTest.php
+++ b/tests/Integration/GlobalRayLoaderTest.php
@@ -8,6 +8,14 @@ it('will resolve ray global function', function () {
     expect(function_exists('ray'))->toBeTrue();
 });
 
-it('will not generate exceptions', function () {
+it('will resolve rd global function', function () {
+    expect(function_exists('rd'))->toBeTrue();
+});
+
+it('will not generate exceptions when calling ray', function () {
     ray('foo');
+})->expectNotToPerformAssertions();
+
+it('will not generate exceptions when calling rd', function () {
+    ray('rd');
 })->expectNotToPerformAssertions();

--- a/tests/Integration/GlobalRayLoaderTest.php
+++ b/tests/Integration/GlobalRayLoaderTest.php
@@ -15,7 +15,3 @@ it('will resolve rd global function', function () {
 it('will not generate exceptions when calling ray', function () {
     ray('foo');
 })->expectNotToPerformAssertions();
-
-it('will not generate exceptions when calling rd', function () {
-    ray('rd');
-})->expectNotToPerformAssertions();


### PR DESCRIPTION
This PR fixes loading the global `dd()` and `dump()` methods. There was a couple things I discovered:

- The order of phar registration matters. When I register the `ray.phar` first, it appears to override the `dump.phar` `dd()` and `dump()` methods. I think this may be due to some internal collisions due to ray depending on the Symfony var dumper.
- Clearing the `__composer_autoload_files` from `$GLOBALS` was required to fix `dd()` and `dump()` issues with Tinkerwell and scripts that have the `dd()` and `dump()` global functions available. Previously, Tinkerwell would fail calling `dd()` due to naming collisions with with its internal composer autoloader.

I've also disabled loading the `dump.phar` when a Tinkerwell environment has been detected. I think we can expand on this detection for other use-cases in the future.

Let me know your thoughts!