### PR TITLE
Ensure global-ray is uninstalled before uninstalling package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,10 @@
         "build": "bin/global-ray build",
         "test": "vendor/bin/pest",
         "test-coverage": "vendor/bin/pest --coverage",
-        "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes"
+        "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes",
+        "pre-package-uninstall": [
+            "bin/global-ray uninstall"
+        ]
     },
     "config": {
         "sort-packages": true,


### PR DESCRIPTION
This PR adds the `global-ray uninstall` command to be performed before `global-ray` is uninstalled via composer on the users system.

This is to ensure their PHP.ini is updated and will not generate an exception due to missing the `global-ray-loader.php` include post-uninstall.