### PR TITLE
Add helper message for installing global ray manually if failed

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -101,7 +101,7 @@ class InstallCommand extends Command
     protected function displayManualInstallation(OutputInterface $output, PhpIni $ini)
     {
         $output->writeln('');
-        $output->writeln("   To install manually, paste the below option into your php.ini configuration file: {$ini->getPath()}...");
+        $output->writeln("   To install manually, paste the below option into your PHP ini configuration file: {$ini->getPath()}...");
         $output->writeln('');
         $output->writeln("auto_prepend_file = {$this->getLoaderPath()}");
         $output->writeln('');

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -6,7 +6,6 @@ use Spatie\GlobalRay\Support\PhpIni;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
@@ -90,7 +89,7 @@ class InstallCommand extends Command
         return 0;
     }
 
-    protected function displaySuccessfulInstallation(Output $output)
+    protected function displaySuccessfulInstallation(OutputInterface $output)
     {
         $output->writeln('   ✅ Successfully updated PHP ini. Global Ray has been installed.');
         $output->writeln('');
@@ -99,7 +98,7 @@ class InstallCommand extends Command
         $output->writeln('');
     }
 
-    protected function displayManualInstallation(Output $output, PhpIni $ini)
+    protected function displayManualInstallation(OutputInterface $output, PhpIni $ini)
     {
         $output->writeln('');
         $output->writeln("   To install manually, paste the below option into your php.ini configuration file: {$ini->getPath()}...");

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -6,6 +6,7 @@ use Spatie\GlobalRay\Support\PhpIni;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
@@ -60,20 +61,16 @@ class InstallCommand extends Command
         $output->writeln('');
         $output->writeln('');
 
-
         if ($ini->update('auto_prepend_file', $this->getLoaderPath())) {
-            $output->writeln('   ✅ Successfully updated PHP ini. Global Ray has been installed.');
-            $output->writeln('');
-            $output->writeln('   ⚡️ Get your Ray license at <href=https://myray.app>https://myray.app</>');
-            $output->writeln('');
-            $output->writeln('   Happy debugging!');
-            $output->writeln('');
+            $this->displaySuccessfulInstallation($output);
 
             return 0;
         }
 
         if (! $this->shouldRetryAsWindowsAdmin($ini, $input)) {
             $output->writeln('   ❌ Unable to update PHP ini.');
+            
+            $this->displayManualInstallation($output, $ini);
 
             return -1;
         }
@@ -83,16 +80,32 @@ class InstallCommand extends Command
         if (! $this->retryAsWindowsAdmin($ini, $input, $output)) {
             $output->writeln('   ❌ Failed updating PHP ini.');
 
+            $this->displayManualInstallation($output, $ini);
+
             return -1;
         }
 
+        $this->displaySuccessfulInstallation($output);
+
+        return 0;
+    }
+
+    protected function displaySuccessfulInstallation(Output $output)
+    {
         $output->writeln('   ✅ Successfully updated PHP ini. Global Ray has been installed.');
         $output->writeln('');
         $output->writeln('   ⚡️ Get your Ray license at <href=https://myray.app>https://myray.app</>');
         $output->writeln('   Happy debugging!');
         $output->writeln('');
+    }
 
-        return 0;
+    protected function displayManualInstallation(Output $output, PhpIni $ini)
+    {
+        $output->writeln('');
+        $output->writeln("   To install manually, paste the below option into your php.ini configuration file: {$ini->getPath()}...");
+        $output->writeln('');
+        $output->writeln("auto_prepend_file = {$this->getLoaderPath()}");
+        $output->writeln('');
     }
 
     protected function getLoaderPath(): string

--- a/src/Commands/RetriesAsWindowsAdmin.php
+++ b/src/Commands/RetriesAsWindowsAdmin.php
@@ -19,7 +19,7 @@ trait RetriesAsWindowsAdmin
 
     protected function retryAsWindowsAdmin(PhpIni $ini, Input $input, Output $output): bool
     {
-        $question = new ConfirmationQuestion('Retry as Adminstrator?', false);
+        $question = new ConfirmationQuestion('   Retry as Adminstrator? (Y/n)', false);
 
         if (! $this->getHelper('question')->ask($input, $output, $question)) {
             return false;

--- a/src/Commands/UninstallCommand.php
+++ b/src/Commands/UninstallCommand.php
@@ -6,7 +6,6 @@ use Spatie\GlobalRay\Support\PhpIni;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class UninstallCommand extends Command
@@ -61,7 +60,7 @@ class UninstallCommand extends Command
         return 0;
     }
 
-    protected function displayManualUninstall(Output $output, PhpIni $ini)
+    protected function displayManualUninstall(OutputInterface $output, PhpIni $ini)
     {
         $output->writeln('');
         $output->writeln("   To uninstall manually, remove the below option from your php.ini configuration file: {$ini->getPath()}...");

--- a/src/Commands/UninstallCommand.php
+++ b/src/Commands/UninstallCommand.php
@@ -6,6 +6,7 @@ use Spatie\GlobalRay\Support\PhpIni;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class UninstallCommand extends Command
@@ -38,7 +39,8 @@ class UninstallCommand extends Command
 
         if (! $this->shouldRetryAsWindowsAdmin($ini, $input)) {
             $output->writeln('  ❌ Unable to update PHP ini.');
-            $output->writeln('');
+
+            $this->displayManualUninstall($output, $ini);
 
             return -1;
         }
@@ -47,7 +49,8 @@ class UninstallCommand extends Command
 
         if (! $this->retryAsWindowsAdmin($ini, $input, $output)) {
             $output->writeln('  ❌ Failed updating PHP ini.');
-            $output->writeln('');
+
+            $this->displayManualUninstall($output, $ini);
 
             return -1;
         }
@@ -56,5 +59,14 @@ class UninstallCommand extends Command
         $output->writeln('');
 
         return 0;
+    }
+
+    protected function displayManualUninstall(Output $output, PhpIni $ini)
+    {
+        $output->writeln('');
+        $output->writeln("   To uninstall manually, remove the below option from your php.ini configuration file: {$ini->getPath()}...");
+        $output->writeln('');
+        $output->writeln("auto_prepend_file = ");
+        $output->writeln('');
     }
 }

--- a/src/Commands/UninstallCommand.php
+++ b/src/Commands/UninstallCommand.php
@@ -63,7 +63,7 @@ class UninstallCommand extends Command
     protected function displayManualUninstall(OutputInterface $output, PhpIni $ini)
     {
         $output->writeln('');
-        $output->writeln("   To uninstall manually, remove the below option from your php.ini configuration file: {$ini->getPath()}...");
+        $output->writeln("   To uninstall manually, remove the below option from your PHP ini configuration file: {$ini->getPath()}...");
         $output->writeln('');
         $output->writeln("auto_prepend_file = ");
         $output->writeln('');


### PR DESCRIPTION
This PR adds a "manual installation" helper message in the event of failure to update the developers `php.ini` file so that they may update it themselves.

Closes #9