### PR TITLE
Add ability to select a loaded `.ini` file for global ray to update

### DIFF
--- a/src/Commands/ConfirmsPhpIniPath.php
+++ b/src/Commands/ConfirmsPhpIniPath.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 
 trait ConfirmsPhpIniPath
 {
-    protected function findPhpIniPath(InputInterface $input, OutputInterface $output)
+    protected function findPhpIniPath(InputInterface $input, OutputInterface $output): string
     {
         if ($iniPath = $input->getOption('ini')) {
             return $iniPath;

--- a/src/Commands/ConfirmsPhpIniPath.php
+++ b/src/Commands/ConfirmsPhpIniPath.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\GlobalRay\Commands;
+
+use Spatie\GlobalRay\Support\PhpIni;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+
+trait ConfirmsPhpIniPath
+{
+    protected function findPhpIniPath(InputInterface $input, OutputInterface $output)
+    {
+        if ($iniPath = $input->getOption('ini')) {
+            return $iniPath;
+        }
+
+        if (count($iniPaths = PhpIni::loaded()) === 1) {
+            return reset($iniPaths);
+        }
+
+        $question = new ChoiceQuestion('   Multiple PHP ini files have been found. Which one would you like to update?', $iniPaths);
+
+        return $this->getHelper('question')->ask($input, $output, $question);
+    }
+}

--- a/src/Commands/ConfirmsPhpIniPath.php
+++ b/src/Commands/ConfirmsPhpIniPath.php
@@ -19,7 +19,7 @@ trait ConfirmsPhpIniPath
             return reset($iniPaths);
         }
 
-        $question = new ChoiceQuestion('   Multiple PHP ini files have been found. Which one would you like to update?', $iniPaths);
+        $question = new ChoiceQuestion('   Multiple loaded PHP ini files have been found. Which one would you like to update?', $iniPaths);
 
         return $this->getHelper('question')->ask($input, $output, $question);
     }

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class InstallCommand extends Command
 {
+    use ConfirmsPhpIniPath;
     use RetriesAsWindowsAdmin;
 
     protected function configure()
@@ -43,18 +44,18 @@ class InstallCommand extends Command
         $output->writeln('   <href=https://spatie.be/docs/ray/v1/usage/framework-agnostic-php-project>https://spatie.be/docs/ray/v1/usage/framework-agnostic-php-project</>');
         $output->writeln('');
 
-        $helper = $this->getHelper('question');
         $question = new ConfirmationQuestion('   🤙 Do you wish to install Ray globally? (Y/n) > ', true);
 
-        if (! $helper->ask($input, $output, $question)) {
+        if (! $this->getHelper('question')->ask($input, $output, $question)) {
             $output->writeln('   Cancelling...');
 
-            return Command::SUCCESS;
+            return 0;
         }
 
-        $output->writeln('');
+        $ini = new PhpIni(
+            $this->findPhpIniPath($input, $output)
+        );
 
-        $ini = new PhpIni($input->getOption('ini'));
         $output->writeln("   Updating PHP ini: {$ini->getPath()}...");
         $output->writeln('');
         $output->writeln('');

--- a/src/Commands/RetriesAsWindowsAdmin.php
+++ b/src/Commands/RetriesAsWindowsAdmin.php
@@ -4,20 +4,20 @@ namespace Spatie\GlobalRay\Commands;
 
 use Spatie\GlobalRay\Support\PhpIni;
 use Spatie\GlobalRay\Support\Platform;
-use Symfony\Component\Console\Input\Input;
-use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 trait RetriesAsWindowsAdmin
 {
-    protected function shouldRetryAsWindowsAdmin(PhpIni $ini, Input $input): bool
+    protected function shouldRetryAsWindowsAdmin(PhpIni $ini, InputInterface $input): bool
     {
         return ! is_writeable($ini->getPath())
             && $input->isInteractive()
             && Platform::isWindowsNonAdminUser();
     }
 
-    protected function retryAsWindowsAdmin(PhpIni $ini, Input $input, Output $output): bool
+    protected function retryAsWindowsAdmin(PhpIni $ini, InputInterface $input, OutputInterface $output): bool
     {
         $question = new ConfirmationQuestion('   Retry as Adminstrator? (Y/n)', false);
 

--- a/src/Commands/UninstallCommand.php
+++ b/src/Commands/UninstallCommand.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class UninstallCommand extends Command
 {
+    use ConfirmsPhpIniPath;
     use RetriesAsWindowsAdmin;
 
     protected function configure()
@@ -22,8 +23,9 @@ class UninstallCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $ini = new PhpIni($input->getOption('ini'));
-
+        $ini = new PhpIni(
+            $this->findPhpIniPath($input, $output)
+        );
 
         $output->writeln('');
         $output->writeln("  Updating PHP ini: {$ini->getPath()}...");

--- a/src/Support/PhpIni.php
+++ b/src/Support/PhpIni.php
@@ -11,7 +11,7 @@ class PhpIni
     public function __construct(string $path = null)
     {
         if (! $path) {
-            $path = get_cfg_var('cfg_file_path');
+            $path = reset(static::loaded());
         }
 
         if (! file_exists($path)) {
@@ -19,6 +19,18 @@ class PhpIni
         }
 
         $this->path = $path;
+    }
+
+    public static function loaded(): array
+    {
+        $files = [
+            php_ini_loaded_file(),
+            ...explode(',', php_ini_scanned_files()),
+        ];
+
+        return array_map(function ($file) {
+            return trim($file);
+        }, $files);
     }
 
     public function update(string $optionName, ?string $value): bool
@@ -46,13 +58,6 @@ class PhpIni
         return $this->path;
     }
 
-    /**
-     * Find the option's line.
-     *
-     * @param string $option
-     *
-     * @return string|false
-     */
     protected function findOptionLine($option)
     {
         $lines = file($this->path);

--- a/src/Support/PhpIni.php
+++ b/src/Support/PhpIni.php
@@ -23,14 +23,14 @@ class PhpIni
 
     public static function loaded(): array
     {
-        $files = [
+        $paths = [
             php_ini_loaded_file(),
             ...explode(',', php_ini_scanned_files()),
         ];
 
-        return array_map(function ($file) {
-            return trim($file);
-        }, $files);
+        return array_map(function ($path) {
+            return trim($path);
+        }, $paths);
     }
 
     public function update(string $optionName, ?string $value): bool

--- a/src/Support/PhpIni.php
+++ b/src/Support/PhpIni.php
@@ -23,14 +23,15 @@ class PhpIni
 
     public static function loaded(): array
     {
-        $paths = [
-            php_ini_loaded_file(),
-            ...explode(',', php_ini_scanned_files()),
-        ];
-
-        return array_map(function ($path) {
+        $paths = array_map(function ($path) {
             return trim($path);
-        }, $paths);
+        }, [
+            php_ini_loaded_file(),
+            get_cfg_var('cfg_file_path'),
+            ...explode(',', php_ini_scanned_files()),
+        ]);
+
+        return array_unique($paths);
     }
 
     public function update(string $optionName, ?string $value): bool


### PR DESCRIPTION
Closes #14 

This PR adds the ability to select an `.ini` file during install/uninstall:

**Install:**
<img width="638" alt="install" src="https://user-images.githubusercontent.com/6421846/157375678-a5e59c28-7e93-45f1-bae9-a37dfcc11408.png">

**Uninstall:**
<img width="638" alt="uninstall" src="https://user-images.githubusercontent.com/6421846/157375684-54eb96bb-5915-4b0d-9d18-ca062ef66ec6.png">

I've decided against updating multiple or all loaded php.ini files, as this is a bit unnecessary since only one of the loaded files needs to be updated for global-ray to be registered properly.