### PR TITLE
Look for valet site composer file

### DIFF
--- a/src/scripts/global-ray-loader.php
+++ b/src/scripts/global-ray-loader.php
@@ -41,8 +41,7 @@ class PharLoader
     {
         $composerJson = getcwd() . '/composer.json';
 
-        // Check if it is Laravel Valet.
-        if(strpos($composerJson, 'valet') != false) {
+        if(strpos($composerJson, 'valet') !== false) {
             $valetConfig = json_decode(file_get_contents($_SERVER['HOME'].'/.config/valet/config.json'));
 
             foreach($valetConfig->paths as $path) {


### PR DESCRIPTION
This PR fixes the path to the `composer.json` file when using a Laravel Valet parked site.

Further context within [this discussion](https://github.com/spatie/global-ray/discussions/22).