### PR TITLE
fix: on macOS if Herd is installed, adjust the valet config file path accordingly

### DIFF
--- a/src/scripts/global-ray-loader.php
+++ b/src/scripts/global-ray-loader.php
@@ -42,7 +42,16 @@ class PharLoader
         $composerJson = getcwd() . '/composer.json';
 
         if (strpos($composerJson, 'valet') !== false) {
-            $valetConfig = json_decode(file_get_contents($_SERVER['HOME'].'/.config/valet/config.json'));
+            $herdConfigPathMacOs = $_SERVER['HOME'] . '/Library/Application Support/Herd/config/valet/config.json';
+            $defaultValetConfigPath = $_SERVER['HOME'] . '/.config/valet/config.json';
+
+            if (PHP_OS_FAMILY === 'Darwin' && file_exists($herdConfigPathMacOs)) { // If MacOS and Herd exists
+                $configPath = $herdConfigPathMacOs;
+            } else {
+                $configPath = $defaultValetConfigPath;
+            }
+
+            $valetConfig = json_decode(file_get_contents($configPath));
 
             foreach ($valetConfig->paths as $path) {
                 $composerPath = $path . '/' . str_replace('.' . $valetConfig->tld, '/', $_SERVER['HTTP_HOST']) . 'composer.json';

--- a/src/scripts/global-ray-loader.php
+++ b/src/scripts/global-ray-loader.php
@@ -43,12 +43,10 @@ class PharLoader
 
         if (strpos($composerJson, 'valet') !== false) {
             $herdConfigPathMacOs = $_SERVER['HOME'] . '/Library/Application Support/Herd/config/valet/config.json';
-            $defaultValetConfigPath = $_SERVER['HOME'] . '/.config/valet/config.json';
+            $configPath = $_SERVER['HOME'] . '/.config/valet/config.json';
 
             if (PHP_OS_FAMILY === 'Darwin' && file_exists($herdConfigPathMacOs)) { // If MacOS and Herd exists
                 $configPath = $herdConfigPathMacOs;
-            } else {
-                $configPath = $defaultValetConfigPath;
             }
 
             $valetConfig = json_decode(file_get_contents($configPath));


### PR DESCRIPTION
On macOS, **Global-Ray** fetches the wrong valet config file when **Herd** is installed. 

This issue has been raised in the past (referenced below) but has not been addressed to date.This PR attempts to fix it on **macOS**. 

Note: Since I do not use Windows or Linux as the host OS, I have not catered for them. **However, my code does check if the system is macOS (Darwin)**.

### Issue referenced here:
- https://github.com/spatie/global-ray/issues/44
- https://github.com/spatie/ray/issues/914
- https://github.com/beyondcode/herd-community/issues/239

As confirmed by @mpociot [here](https://github.com/beyondcode/herd-community/issues/239#issuecomment-1850112217), this issue is not related to Herd but rather with how **Global-Ray** fetches the valet config file.