### PR TITLE
Add return type declarations

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -19,7 +19,7 @@ class BuildCommand extends Command
             ->setDescription('Build the Ray Phar');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln('Building phars...');
 

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -22,7 +22,7 @@ class InstallCommand extends Command
             ->addOption('ini', null, InputOption::VALUE_REQUIRED, 'The full path to the PHP ini that should be updated');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln('');
         $output->writeln('   ⚡️ Ray is a wonderful desktop application that will let you');

--- a/src/Commands/UninstallCommand.php
+++ b/src/Commands/UninstallCommand.php
@@ -21,7 +21,7 @@ class UninstallCommand extends Command
             ->addOption('ini', null, InputOption::VALUE_REQUIRED, 'The full path to the PHP ini that should be updated');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $ini = new PhpIni(
             $this->findPhpIniPath($input, $output)


### PR DESCRIPTION
Fatal error when running `global-ray install`.

```
$global-ray install...

Fatal error: Declaration of Spatie\GlobalRay\Commands\InstallCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in /Users/luke/.composer/vendor/spatie/global-ray/src/Commands/InstallCommand.php on line 25
```

Don't know if it was my PHP version, or Laravel Herd, but I just wanted to use the vanilla JS version of Ray, and now I can.