### PR TITLE
Changes implicitly nullable parameter types

### DIFF
--- a/src/Support/PhpIni.php
+++ b/src/Support/PhpIni.php
@@ -8,7 +8,7 @@ class PhpIni
 {
     protected $path;
 
-    public function __construct(string $path = null)
+    public function __construct(?string $path = null)
     {
         if (! $path) {
             $path = reset(static::loaded());


### PR DESCRIPTION
On PHP 8.4 the packages shows a depreciation warning during the install script.

```
Deprecated: Spatie\GlobalRay\Support\PhpIni::__construct(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in /Users/username/.composer/vendor/spatie/global-ray/src/Support/PhpIni.php on line 11
```

This is because implicit nullable parameter types are not allowed anymore. Fixed by making the paramter explicitly nullable.